### PR TITLE
Comment buttons panel changes, enum and storing comment text

### DIFF
--- a/src/app/common/markdown-editor/markdown-editor.coffee
+++ b/src/app/common/markdown-editor/markdown-editor.coffee
@@ -13,6 +13,10 @@ angular.module('doubtfire.common.markdown-editor', [])
     onEnter: '=?'
   controller: ($scope, $timeout) ->
     DEFAULT_HEIGHT = 300
+
+    $scope.commentType = {TEXT : 0, AUDIO : 1} # Enum for keeping track of comment type
+    $scope.currentCommentType = $scope.commentType.TEXT # Current value of comment type
+
     $scope.isEditing = true
     $scope.height = $scope.height or DEFAULT_HEIGHT
     $scope.codemirrorLoaded = (editor) ->

--- a/src/app/common/markdown-editor/markdown-editor.scss
+++ b/src/app/common/markdown-editor/markdown-editor.scss
@@ -22,7 +22,7 @@ $markdown-editor-height: 15px;
     }
   }
 
-.markdown-editor, .markdown-editor-inner-context-text, .markdown-editor-inner-context-audio {
+.markdown-editor, .markdown-editor-inner-context-text {
   position: relative;
   cursor: text;
   padding: 6px 12px;
@@ -33,6 +33,12 @@ $markdown-editor-height: 15px;
   font-size: 1em;
   background-color: #fff;
 
+  // Additional style for audio comment editor
+  .markdown-editor-inner-context-audio {
+    height: 60px;
+    background-color: rgb(231, 101, 101);
+  }
+  
   .markdown-editor-preview {
     display: relative;
     overflow-y: hidden;
@@ -137,8 +143,3 @@ $markdown-editor-height: 15px;
   text-align: center;
 }
 
-// Additional style for audio comment editor
-.markdown-editor-inner-context-audio {
-  height: 60px;
-  background-color: rgb(231, 101, 101);
-}

--- a/src/app/common/markdown-editor/markdown-editor.scss
+++ b/src/app/common/markdown-editor/markdown-editor.scss
@@ -22,7 +22,7 @@ $markdown-editor-height: 15px;
     }
   }
 
-.markdown-editor .markdown-editor-inner-context {
+.markdown-editor, .markdown-editor-inner-context-text, .markdown-editor-inner-context-audio {
   position: relative;
   cursor: text;
   padding: 6px 12px;
@@ -137,3 +137,8 @@ $markdown-editor-height: 15px;
   text-align: center;
 }
 
+// Additional style for audio comment editor
+.markdown-editor-inner-context-audio {
+  height: 60px;
+  background-color: rgb(231, 101, 101);
+}

--- a/src/app/common/markdown-editor/markdown-editor.tpl.html
+++ b/src/app/common/markdown-editor/markdown-editor.tpl.html
@@ -1,34 +1,40 @@
 <div class="markdown-editor">
-  <div class="markdown-editor-inner-context">
+  <!-- Text comment editor --> 
+  <div class="markdown-editor-inner-context-text" ng-show="currentCommentType == commentType.TEXT">
     <div ng-show="isEditing" ui-codemirror="{ onLoad : codemirrorLoaded }" ui-codemirror-opts="editorOpts" ui-refresh="true"
-      ng-model="markdownText"></div>
+      ng-model="markdownText"></div>    
     <div style="{{heightStyle()}}" class="markdown-editor-preview markdown-to-html" ng-hide="isEditing">
       <div ng-bind-html="markdownText | markdown"></div>
     </div>
   </div>
+ <!-- Audio comment editor -->
+  <div class="markdown-editor-inner-context-audio" ng-show="currentCommentType == commentType.AUDIO">
+    <div>
+       <!-- POC comes here -->
+    </div>   
+  </div>
+  
   <div class="markdown-editor-actions">
+    <!-- PREVIEW COMMENT -->
     <span ng-click="isEditing = !isEditing" class="markdown-editor-action fa-stack fa-lg" tooltip="{{isEditing ? 'View preview' : 'Continue editing'}}">
       <i class="fa fa-{{isEditing ? 'eye' : 'pencil'}} fa-stack-1x"></i>
     </span>
+    <!-- MARKDOWN GUIDE -->
     <a href="https://en.support.wordpress.com/markdown-quick-reference/" target="_blank" class="markdown-editor-action fa-stack fa-lg"
       tooltip="Markdown guide">
       <i class="fa fa-question fa-stack-1x"></i>
-    </a>
-    
-    <!-- Comment Type Selector Icons -->
-    <!-- =========================== -->
+    </a>  
+    <!-- COMMENT TYPE SELECTOR ICONS --> 
     <font color="#cecece">|</font>
-
     <!-- Text -->
-    <span class="markdown-editor-action fa-stack fa-lg" tooltip="Text comment">
+    <!-- Clicking on the span changes the value of the comment type enum -->
+    <span ng-click="currentCommentType = commentType.TEXT" class="markdown-editor-action fa-stack fa-lg" tooltip="Text comment">
       <i class="fa fa-font commenttype-selector"></i>
     </span>
-
     <!-- Audio -->
-    <span class="markdown-editor-action fa-stack fa-lg" tooltip="Audio comment">
+    <span ng-click="currentCommentType = commentType.AUDIO" class="markdown-editor-action fa-stack fa-lg" tooltip="Audio comment">
       <i class="fa fa-microphone commenttype-selector"></i>
-    </span>
-    <!-- =========================== -->
-    
+    </span>    
   </div>
+
 </div>


### PR DESCRIPTION
- Comment buttons hide and show their associated panels.
- When a comment type button is pressed, the current comment type variable is set to the associated enum value.
- The text in the text comment editor is already stored in a variable and is preserved when comment type is changed.